### PR TITLE
changed schedule run from 9AM to 7AM and vuln fix

### DIFF
--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 7 * * 1-5" # Every weekday at 7AM UTC
   workflow_dispatch:
 
 permissions: {}
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@aa8abd093cd24a89b8dd2d76b6733d8121c64c52 # v8.0.3
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}

--- a/.grype.yml
+++ b/.grype.yml
@@ -173,6 +173,6 @@ ignore:
 
   - vulnerability: GHSA-52v5-jr5w-gjxr
     reason: "Bundled in Shiny Server npm dependency (sigstore 2.3.1); temporary exception pending upstream update to >=4.1.1."
-  
+
   - vulnerability: GHSA-xv26-6w52-cph6
     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."

--- a/.grype.yml
+++ b/.grype.yml
@@ -173,3 +173,6 @@ ignore:
 
   - vulnerability: GHSA-52v5-jr5w-gjxr
     reason: "Bundled in Shiny Server npm dependency (sigstore 2.3.1); temporary exception pending upstream update to >=4.1.1."
+  
+  - vulnerability: GHSA-xv26-6w52-cph6
+      reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."

--- a/.grype.yml
+++ b/.grype.yml
@@ -175,4 +175,4 @@ ignore:
     reason: "Bundled in Shiny Server npm dependency (sigstore 2.3.1); temporary exception pending upstream update to >=4.1.1."
   
   - vulnerability: GHSA-xv26-6w52-cph6
-      reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,12 @@ RUN apt-get update -y && \
   libssl-dev \
   libsqlite3-dev \
   python3-boto \
-  xtail
+  xtail \
+  libncursesw6=6.4+20240113-1ubuntu2.1 \
+  libtinfo6=6.4+20240113-1ubuntu2.1 \
+  ncurses-base=6.4+20240113-1ubuntu2.1 \
+  ncurses-bin=6.4+20240113-1ubuntu2.1 \
+  gzip=1.12-1ubuntu3.2
 
 
 # APT Cleanup


### PR DESCRIPTION
Changed the schedule to run at `7 AM UTC` instead of `9 AM`, because we're using a shared runner, which doesn't guarantee the exact scheduled run time. This way, by the time our office hours start, we should already have the scan results. Additional changes
- pinned these versions
```
  libncursesw6=6.4+20240113-1ubuntu2.1 
  libtinfo6=6.4+20240113-1ubuntu2.1 
  ncurses-base=6.4+20240113-1ubuntu2.1 
  ncurses-bin=6.4+20240113-1ubuntu2.1 
  gzip=1.12-1ubuntu3.2
```
- added ignore for known vuln - `GHSA-xv26-6w52-cph6`



PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/529) ticket.