### PR TITLE
testing CVE's in new base image

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -1,188 +1,188 @@
----
-# Grype configuration for container vulnerability scanning
-# https://github.com/anchore/grype#configuration
+# ---
+# # Grype configuration for container vulnerability scanning
+# # https://github.com/anchore/grype#configuration
 
-ignore:
-  # linux-libc-dev (kernel headers)
-  # These CVEs are in the Linux kernel, not in the container image filesystem.
-  # The runtime kernel is provided and patched by the Kubernetes node host.
-  - vulnerability: CVE-2025-38666
-    reason: "Kernel vulnerability in linux-libc-dev headers; runtime kernel is host-managed."
+# ignore:
+#   # linux-libc-dev (kernel headers)
+#   # These CVEs are in the Linux kernel, not in the container image filesystem.
+#   # The runtime kernel is provided and patched by the Kubernetes node host.
+#   - vulnerability: CVE-2025-38666
+#     reason: "Kernel vulnerability in linux-libc-dev headers; runtime kernel is host-managed."
 
-  - vulnerability: CVE-2025-38561
-    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+#   - vulnerability: CVE-2025-38561
+#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-  - vulnerability: CVE-2025-39698
-    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+#   - vulnerability: CVE-2025-39698
+#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-  - vulnerability: CVE-2025-37899
-    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+#   - vulnerability: CVE-2025-37899
+#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-  - vulnerability: CVE-2025-37849
-    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+#   - vulnerability: CVE-2025-37849
+#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-  # Node.js / Shiny Server transitive dependencies
-  - vulnerability: CVE-2024-21538
-    reason: "Transitive dependency; tracked for upstream fix."
+#   # Node.js / Shiny Server transitive dependencies
+#   - vulnerability: CVE-2024-21538
+#     reason: "Transitive dependency; tracked for upstream fix."
 
-  - vulnerability: CVE-2025-64756
-    reason: "Transitive dependency; tracked for upstream fix."
+#   - vulnerability: CVE-2025-64756
+#     reason: "Transitive dependency; tracked for upstream fix."
 
-  - vulnerability: CVE-2024-52798
-    reason: "Transitive dependency; tracked for upstream fix."
+#   - vulnerability: CVE-2024-52798
+#     reason: "Transitive dependency; tracked for upstream fix."
 
-  - vulnerability: CVE-2025-22088
-    reason: "Transitive dependency; tracked for upstream fix."
+#   - vulnerability: CVE-2025-22088
+#     reason: "Transitive dependency; tracked for upstream fix."
 
-  - vulnerability: CVE-2025-15284
-    reason: "qs DoS is not exploitable in this R Shiny context; query parsing is handled by R."
+#   - vulnerability: CVE-2025-15284
+#     reason: "qs DoS is not exploitable in this R Shiny context; query parsing is handled by R."
 
-  # Ubuntu dependency
-  - vulnerability: CVE-2025-68973
-    reason: "Upstream dependency issue; tracked for upstream fix."
+#   # Ubuntu dependency
+#   - vulnerability: CVE-2025-68973
+#     reason: "Upstream dependency issue; tracked for upstream fix."
 
-  # tar / minimatch / underscore / flatted transitive dependencies
-  - vulnerability: CVE-2026-23745
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   # tar / minimatch / underscore / flatted transitive dependencies
+#   - vulnerability: CVE-2026-23745
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-23950
-    reason: "Affects macOS-specific filesystem behavior; not applicable to Linux container runtime."
+#   - vulnerability: CVE-2026-23950
+#     reason: "Affects macOS-specific filesystem behavior; not applicable to Linux container runtime."
 
-  - vulnerability: CVE-2026-24842
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-24842
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-31802
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-31802
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-26960
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-26960
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: GHSA-qffp-2rhf-9h96
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: GHSA-qffp-2rhf-9h96
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-29786
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-29786
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-26996
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-26996
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-27903
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-27903
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-27904
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-27904
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-27601
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-27601
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  - vulnerability: CVE-2026-32141
-    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+#   - vulnerability: CVE-2026-32141
+#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-  # 2026-07 temporary suppressions from latest container scan
-  # Base image package (libgnutls30t64) findings
-  - vulnerability: CVE-2026-42010
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   # 2026-07 temporary suppressions from latest container scan
+#   # Base image package (libgnutls30t64) findings
+#   - vulnerability: CVE-2026-42010
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-33845
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-33845
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-42009
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-42009
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-33846
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-33846
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-5260
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-5260
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-3833
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-3833
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-42011
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-42011
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-42013
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-42013
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  - vulnerability: CVE-2026-42012
-    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+#   - vulnerability: CVE-2026-42012
+#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-  # Shiny Server bundled Node.js dependency findings
-  - vulnerability: GHSA-2w6w-674q-4c4q
-    reason: "Bundled in Shiny Server node_modules; no newer Shiny Server release currently available."
+#   # Shiny Server bundled Node.js dependency findings
+#   - vulnerability: GHSA-2w6w-674q-4c4q
+#     reason: "Bundled in Shiny Server node_modules; no newer Shiny Server release currently available."
 
-  - vulnerability: GHSA-5j98-mcp5-4vw2
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-5j98-mcp5-4vw2
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-3xgq-45jj-v275
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-3xgq-45jj-v275
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-rhx6-c78j-4q9w
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-rhx6-c78j-4q9w
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-rf6f-7fwh-wjgh
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-rf6f-7fwh-wjgh
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-xhpv-hc6g-r9c6
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-xhpv-hc6g-r9c6
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-3mfm-83xf-c92r
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-3mfm-83xf-c92r
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-qpx9-hpmf-5gmw
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-qpx9-hpmf-5gmw
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-3ppc-4f35-3m26
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-3ppc-4f35-3m26
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-25h7-pfq9-p65f
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-25h7-pfq9-p65f
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-34x7-hfp2-rc4v
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-34x7-hfp2-rc4v
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-9cx6-37pm-9jff
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-9cx6-37pm-9jff
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-7r86-cg39-jmmj
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-7r86-cg39-jmmj
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-37ch-88jc-xwx2
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-37ch-88jc-xwx2
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-23c5-xmqv-rm74
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-23c5-xmqv-rm74
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-8qq5-rm4j-mr97
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-8qq5-rm4j-mr97
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-xjpj-3mr7-gcpf
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-xjpj-3mr7-gcpf
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-83g3-92jg-28cx
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-83g3-92jg-28cx
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-w5hq-g745-h8pq
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-w5hq-g745-h8pq
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-9ppj-qmqm-q256
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-9ppj-qmqm-q256
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-r6q2-hw4h-h46w
-    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+#   - vulnerability: GHSA-r6q2-hw4h-h46w
+#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-  - vulnerability: GHSA-52v5-jr5w-gjxr
-    reason: "Bundled in Shiny Server npm dependency (sigstore 2.3.1); temporary exception pending upstream update to >=4.1.1."
+#   - vulnerability: GHSA-52v5-jr5w-gjxr
+#     reason: "Bundled in Shiny Server npm dependency (sigstore 2.3.1); temporary exception pending upstream update to >=4.1.1."
 
-  - vulnerability: GHSA-xv26-6w52-cph6
-    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+#   - vulnerability: GHSA-xv26-6w52-cph6
+#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-  # 2026-07 Shiny Server bundled npm findings (requested time-bound suppressions)
-  - vulnerability: GHSA-23hp-3jrh-7fpw
-    reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/20206."
+#   # 2026-07 Shiny Server bundled npm findings (requested time-bound suppressions)
+#   - vulnerability: GHSA-23hp-3jrh-7fpw
+#     reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/20206."
 
-  - vulnerability: GHSA-8x88-c5mf-7j5w
-    reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/20206."
+#   - vulnerability: GHSA-8x88-c5mf-7j5w
+#     reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/20206."
 
-  - vulnerability: GHSA-3jxr-9vmj-r5cp
-    reason: "Bundled in Shiny Server npm dependency tree (brace-expansion 2.0.1); temporary exception pending upstream update. Expiry: 01/08/20206."
+#   - vulnerability: GHSA-3jxr-9vmj-r5cp
+#     reason: "Bundled in Shiny Server npm dependency tree (brace-expansion 2.0.1); temporary exception pending upstream update. Expiry: 01/08/20206."

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,188 +1,195 @@
-# ---
-# # Grype configuration for container vulnerability scanning
-# # https://github.com/anchore/grype#configuration
+# Grype configuration for container vulnerability scanning
+# https://github.com/anchore/grype#configuration
 
-# ignore:
-#   # linux-libc-dev (kernel headers)
-#   # These CVEs are in the Linux kernel, not in the container image filesystem.
-#   # The runtime kernel is provided and patched by the Kubernetes node host.
-#   - vulnerability: CVE-2025-38666
-#     reason: "Kernel vulnerability in linux-libc-dev headers; runtime kernel is host-managed."
+ignore:
+  # linux-libc-dev (kernel headers)
+  # These CVEs are in the Linux kernel, not in the container image filesystem.
+  # The runtime kernel is provided and patched by the Kubernetes node host.
+  - vulnerability: CVE-2025-38666
+    reason: "Kernel vulnerability in linux-libc-dev headers; runtime kernel is host-managed."
 
-#   - vulnerability: CVE-2025-38561
-#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+  - vulnerability: CVE-2025-38561
+    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-#   - vulnerability: CVE-2025-39698
-#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+  - vulnerability: CVE-2025-39698
+    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-#   - vulnerability: CVE-2025-37899
-#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+  - vulnerability: CVE-2025-37899
+    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-#   - vulnerability: CVE-2025-37849
-#     reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
+  - vulnerability: CVE-2025-37849
+    reason: "Kernel vulnerability in linux-libc-dev headers; temporary exception."
 
-#   # Node.js / Shiny Server transitive dependencies
-#   - vulnerability: CVE-2024-21538
-#     reason: "Transitive dependency; tracked for upstream fix."
+  # Node.js / Shiny Server transitive dependencies
+  - vulnerability: CVE-2024-21538
+    reason: "Transitive dependency; tracked for upstream fix."
 
-#   - vulnerability: CVE-2025-64756
-#     reason: "Transitive dependency; tracked for upstream fix."
+  - vulnerability: CVE-2025-64756
+    reason: "Transitive dependency; tracked for upstream fix."
 
-#   - vulnerability: CVE-2024-52798
-#     reason: "Transitive dependency; tracked for upstream fix."
+  - vulnerability: CVE-2024-52798
+    reason: "Transitive dependency; tracked for upstream fix."
 
-#   - vulnerability: CVE-2025-22088
-#     reason: "Transitive dependency; tracked for upstream fix."
+  - vulnerability: CVE-2025-22088
+    reason: "Transitive dependency; tracked for upstream fix."
 
-#   - vulnerability: CVE-2025-15284
-#     reason: "qs DoS is not exploitable in this R Shiny context; query parsing is handled by R."
+  - vulnerability: CVE-2025-15284
+    reason: "qs DoS is not exploitable in this R Shiny context; query parsing is handled by R."
 
-#   # Ubuntu dependency
-#   - vulnerability: CVE-2025-68973
-#     reason: "Upstream dependency issue; tracked for upstream fix."
+  # Ubuntu dependency
+  - vulnerability: CVE-2025-68973
+    reason: "Upstream dependency issue; tracked for upstream fix."
 
-#   # tar / minimatch / underscore / flatted transitive dependencies
-#   - vulnerability: CVE-2026-23745
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  # tar / minimatch / underscore / flatted transitive dependencies
+  - vulnerability: CVE-2026-23745
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-23950
-#     reason: "Affects macOS-specific filesystem behavior; not applicable to Linux container runtime."
+  - vulnerability: CVE-2026-23950
+    reason: "Affects macOS-specific filesystem behavior; not applicable to Linux container runtime."
 
-#   - vulnerability: CVE-2026-24842
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-24842
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-31802
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-31802
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-26960
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-26960
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: GHSA-qffp-2rhf-9h96
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: GHSA-qffp-2rhf-9h96
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-29786
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-29786
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-26996
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-26996
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-27903
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-27903
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-27904
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-27904
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-27601
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-27601
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   - vulnerability: CVE-2026-32141
-#     reason: "Bundled transitive dependency; temporary exception pending upstream updates."
+  - vulnerability: CVE-2026-32141
+    reason: "Bundled transitive dependency; temporary exception pending upstream updates."
 
-#   # 2026-07 temporary suppressions from latest container scan
-#   # Base image package (libgnutls30t64) findings
-#   - vulnerability: CVE-2026-42010
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  # 2026-07 temporary suppressions from latest container scan
+  # Base image package (libgnutls30t64) findings
+  - vulnerability: CVE-2026-42010
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-33845
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-33845
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-42009
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-42009
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-33846
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-33846
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-5260
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-5260
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-3833
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-3833
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-42011
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-42011
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-42013
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-42013
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   - vulnerability: CVE-2026-42012
-#     reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
+  - vulnerability: CVE-2026-42012
+    reason: "Fixed upstream in newer base image package revision; temporary exception until base image ships patched package."
 
-#   # Shiny Server bundled Node.js dependency findings
-#   - vulnerability: GHSA-2w6w-674q-4c4q
-#     reason: "Bundled in Shiny Server node_modules; no newer Shiny Server release currently available."
+  # Kerberos library findings (libgssapi-krb5-2, libk5crypto3, libkrb5-3, libkrb5support0)
+  # Fixed in 1.20.1-6ubuntu2.7; temporary exception until base image ships patched package.
+  - vulnerability: CVE-2026-40355
+    reason: "Fixed upstream in 1.20.1-6ubuntu2.7; temporary exception until base image ships patched package."
 
-#   - vulnerability: GHSA-5j98-mcp5-4vw2
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: CVE-2026-40356
+    reason: "Fixed upstream in 1.20.1-6ubuntu2.7; temporary exception until base image ships patched package."
 
-#   - vulnerability: GHSA-3xgq-45jj-v275
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  # Shiny Server bundled Node.js dependency findings
+  - vulnerability: GHSA-2w6w-674q-4c4q
+    reason: "Bundled in Shiny Server node_modules; no newer Shiny Server release currently available."
 
-#   - vulnerability: GHSA-rhx6-c78j-4q9w
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-xv26-6w52-cph6
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-rf6f-7fwh-wjgh
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-5j98-mcp5-4vw2
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-xhpv-hc6g-r9c6
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-3xgq-45jj-v275
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-3mfm-83xf-c92r
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-rhx6-c78j-4q9w
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-qpx9-hpmf-5gmw
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-rf6f-7fwh-wjgh
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-3ppc-4f35-3m26
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-xhpv-hc6g-r9c6
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-25h7-pfq9-p65f
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-3mfm-83xf-c92r
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-34x7-hfp2-rc4v
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-qpx9-hpmf-5gmw
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-9cx6-37pm-9jff
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-3ppc-4f35-3m26
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-7r86-cg39-jmmj
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-25h7-pfq9-p65f
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-37ch-88jc-xwx2
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-34x7-hfp2-rc4v
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-23c5-xmqv-rm74
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-9cx6-37pm-9jff
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-8qq5-rm4j-mr97
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-7r86-cg39-jmmj
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-xjpj-3mr7-gcpf
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-37ch-88jc-xwx2
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-83g3-92jg-28cx
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-23c5-xmqv-rm74
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-w5hq-g745-h8pq
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-8qq5-rm4j-mr97
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-9ppj-qmqm-q256
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-xjpj-3mr7-gcpf
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-r6q2-hw4h-h46w
-#     reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
+  - vulnerability: GHSA-83g3-92jg-28cx
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-52v5-jr5w-gjxr
-#     reason: "Bundled in Shiny Server npm dependency (sigstore 2.3.1); temporary exception pending upstream update to >=4.1.1."
+  - vulnerability: GHSA-w5hq-g745-h8pq
+    reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-xv26-6w52-cph6
-#     reason: "Bundled in Shiny Server node_modules; temporary exception pending upstream update."
+  - vulnerability: GHSA-9ppj-qmqm-q256
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   # 2026-07 Shiny Server bundled npm findings (requested time-bound suppressions)
-#   - vulnerability: GHSA-23hp-3jrh-7fpw
-#     reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/20206."
+  - vulnerability: GHSA-r6q2-hw4h-h46w
+    reason: "Bundled in Shiny Server/npm dependency tree; temporary exception pending upstream update."
 
-#   - vulnerability: GHSA-8x88-c5mf-7j5w
-#     reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/20206."
+  - vulnerability: GHSA-52v5-jr5w-gjxr
+    reason: "Bundled in Shiny Server npm dependency (sigstore 2.3.1); temporary exception pending upstream update to >=4.1.1."
 
-#   - vulnerability: GHSA-3jxr-9vmj-r5cp
-#     reason: "Bundled in Shiny Server npm dependency tree (brace-expansion 2.0.1); temporary exception pending upstream update. Expiry: 01/08/20206."
+  # 2026-07 Shiny Server bundled npm findings (requested time-bound suppressions)
+  - vulnerability: GHSA-23hp-3jrh-7fpw
+    reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/2026."
+
+  - vulnerability: GHSA-8x88-c5mf-7j5w
+    reason: "Bundled in Shiny Server npm dependency tree (tar 6.2.1); temporary exception pending upstream update. Expiry: 01/08/2026."
+
+  - vulnerability: GHSA-3jxr-9vmj-r5cp
+    reason: "Bundled in Shiny Server npm dependency tree (brace-expansion 2.0.1); temporary exception pending upstream update. Expiry: 01/08/2026."

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # checkov:skip=CKV_DOCKER_3:"Ensure that a user for the container has been created"
 # hadolint global ignore=DL3008
 
-FROM docker.io/rocker/r-ver:4.6.1@sha256:dabd504d048dff9a47e4247db4b367a30df96a3190ddb19fab64eef3775d3793
+FROM docker.io/rocker/r-ver:4.6.1@sha256:555a0e7734b17f3901f01c8e379f87d797a0e6344a4cc3b246329ed3f0689809
 
 ARG shinyserver=1.5.23.1030
 ENV SHINY_SERVER_VERSION=${shinyserver}


### PR DESCRIPTION
This pull request updates the container base image and refines the vulnerability suppression list for container scanning. The main changes include switching to a newer `rocker/r-ver` image digest in the `Dockerfile`, adding and adjusting vulnerability exceptions in `.grype.yml`, and fixing some expiry date typos.

**Dependency updates:**
* Updated the base image digest in the `Dockerfile` to use `sha256:555a0e7...` instead of the previous digest, ensuring the build uses the latest verified image.

**Vulnerability scan configuration:**
* Added temporary exceptions for Kerberos-related CVEs (`CVE-2026-40355`, `CVE-2026-40356`) to `.grype.yml`, with notes that these are fixed upstream but pending in the base image.
* Moved the `GHSA-xv26-6w52-cph6` exception to a more appropriate section for Shiny Server bundled Node.js dependencies. [[1]](diffhunk://#diff-5daeb107f00145e4181b32f14e4cfa38861fe6a7193bb7e71e967f9922e74567R109-R123) [[2]](diffhunk://#diff-5daeb107f00145e4181b32f14e4cfa38861fe6a7193bb7e71e967f9922e74567L177-R195)
* Corrected expiry date typos for several Shiny Server npm dependency exceptions from `01/08/20206` to `01/08/2026`.