### PR TITLE
CVE Fix - add libc packages to the update block

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,12 @@ RUN apt-get update -y && \
   libtinfo6=6.4+20240113-1ubuntu2.1 \
   ncurses-base=6.4+20240113-1ubuntu2.1 \
   ncurses-bin=6.4+20240113-1ubuntu2.1 \
-  gzip=1.12-1ubuntu3.2
+  gzip=1.12-1ubuntu3.2 \
+  libc6=2.39-0ubuntu8.8 \
+  libc-bin=2.39-0ubuntu8.8 \
+  libc-dev-bin=2.39-0ubuntu8.8 \
+  libc6-dev=2.39-0ubuntu8.8 \
+  locales=2.39-0ubuntu8.8
 
 
 # APT Cleanup


### PR DESCRIPTION
This pull request updates the `Dockerfile` to include several additional core system libraries in the build environment. The main change is the explicit installation of updated versions of the GNU C Library (`libc6`) and related packages, which can improve compatibility and security.

Dependency updates:

* Added `libc6`, `libc-bin`, `libc-dev-bin`, `libc6-dev`, and `locales` (all version `2.39-0ubuntu8.8`) to the list of installed packages to ensure the container has up-to-date core system libraries.